### PR TITLE
Add ore to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM registry.fedoraproject.org/fedora:28
 # rsync, python2, pygobject3-base are dependencies of ostree-releng-scripts
 # Also add python3 so people can use that too.
-RUN yum -y install rpm-ostree make cargo git \
-    rsync pygobject3-base python3-gobject-base \
+RUN yum -y install rpm-ostree make cargo golang git jq \
+    rsync pygobject3-base python3-gobject-base awscli \
     && yum clean all
 ADD build.sh /root
 RUN mkdir /root/src

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/bash
 set -xeuo pipefail
+
 mkdir -p /usr/app/
 cd /usr/app/
 git clone https://github.com/ostreedev/ostree-releng-scripts
+
 cd /root/src
 ls -al
 cargo build --release
 mv target/release/coreos-assembler /usr/bin
 rm target -rf
+
+cd /root
+git clone https://github.com/coreos/mantle
+# for now just build ore, we can add more components as we use them
+mantle/build ore
+mv mantle/bin/ore /usr/bin
+rm mantle -rf


### PR DESCRIPTION
This builds and installs mantle's `ore` binary as well as some other
useful utilities like `jq` and `awscli`. Then we should be able to fully
migrate the cloud pipeline.