### PR TITLE
Minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-
+/Cargo.lock
+/coreos-assembler
 /target
 **/*.rs.bk

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+PREFIX ?= "./"
+
+.PHONY: clean check
+
+clean:
+	rm -rf target/
+	rm -f coreos-assembler
+
+build:
+	cargo build --release
+	mv target/release/coreos-assembler ${PREFIX}
+
+check:
+	find . -name "*.rs" | xargs rustfmt --write-mode diff

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn main() {
     ::process::exit(match run() {
         Ok(_) => 0,
         Err(e) => {
-            println!("{}", e);
+            eprintln!("{}", e);
             1
         }
     })

--- a/src/treefile.rs
+++ b/src/treefile.rs
@@ -60,7 +60,7 @@ pub struct TreeComposeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub install_langs: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="initramfs-args")]
+    #[serde(rename = "initramfs-args")]
     pub initramfs_args: Option<Vec<String>>,
 
     // Tree layout options
@@ -81,38 +81,38 @@ pub struct TreeComposeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub automatic_version_prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="mutate-os-relase")]
+    #[serde(rename = "mutate-os-relase")]
     pub mutate_os_release: Option<String>,
 
     // passwd-related bits
     #[serde(skip_serializing_if = "Option::is_none")]
     pub etc_group_members: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="preserve-passwd")]
+    #[serde(rename = "preserve-passwd")]
     pub preserve_passwd: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="check-passwd")]
+    #[serde(rename = "check-passwd")]
     pub check_passwd: Option<CheckPasswd>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="check-groups")]
+    #[serde(rename = "check-groups")]
     pub check_groups: Option<CheckPasswd>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="ignore-removed-users")]
+    #[serde(rename = "ignore-removed-users")]
     pub ignore_removed_users: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="ignore-removed-groups")]
+    #[serde(rename = "ignore-removed-groups")]
     pub ignore_removed_groups: Option<Vec<String>>,
 
     // Content manimulation
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="postprocess-script")]
+    #[serde(rename = "postprocess-script")]
     pub postprocess_script: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="add-files")]
+    #[serde(rename = "add-files")]
     pub add_files: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remove_files: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="remove-from-packages")]
+    #[serde(rename = "remove-from-packages")]
     pub remove_from_packages: Option<Vec<Vec<String>>>,
 }


### PR DESCRIPTION
- Use `eprintln` for cli error
- Follow rust preferred formatting
- Add `Makefile` with `build`, `clean`, and `check`
- Ignore generated files