### PR TITLE
Dockerfile: install ostree/rpm-ostree from FAHC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM registry.fedoraproject.org/fedora:28
 ADD build.sh /root
+ADD fahc.repo /etc/yum.repos.d/
 RUN mkdir /root/src
 COPY Makefile Cargo.toml /root/src/
 COPY src /root/src/src

--- a/fahc.repo
+++ b/fahc.repo
@@ -1,0 +1,3 @@
+[fahc]
+baseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/jigdo
+gpgcheck=0


### PR DESCRIPTION
For https://github.com/projectatomic/rpm-ostree/pull/1417. Though it's nice in general too to be running this with the latest and greatest (or worst).