### PR TITLE
build: bring in additional tooling to enable building RHCOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -xeuo pipefail
 # rsync, python2, pygobject3-base are dependencies of ostree-releng-scripts
 # Also add python3 so people can use that too.
 # createrepo_c+yum-utils is used for managing rojig bits.
-yum -y install rpm-ostree selinux-policy-targeted rpm-build \
+dnf -y install rpm-ostree selinux-policy-targeted rpm-build \
     make cargo golang git jq \
     rsync pygobject3-base python3-gobject-base \
     createrepo_c dnf-utils
@@ -23,7 +23,7 @@ cd /
 rm /root/src -rf
 
 # Part of general image management
-yum -y install awscli
+dnf -y install awscli
 cd /root
 git clone https://github.com/coreos/mantle
 # for now just build ore, we can add more components as we use them
@@ -35,10 +35,6 @@ dnf remove -y cargo golang
 rpm -q grubby && dnf remove -y grubby
 
 # more tooling for building openshift/os in the container
-cd /root
-git clone https://github.com/openshift/os
-cp os/RPM-GPG-KEY* /etc/pki/rpm-gpg/
-rm os -rf
 dnf copr -y enable walters/buildtools-fedora
 dnf -y install dnf-plugins-core fedpkg openssh-clients rpmdistro-gitoverlay
-yum clean all
+dnf clean all

--- a/build.sh
+++ b/build.sh
@@ -33,4 +33,12 @@ rm mantle -rf
 
 dnf remove -y cargo golang
 rpm -q grubby && dnf remove -y grubby
+
+# more tooling for building openshift/os in the container
+cd /root
+git clone https://github.com/openshift/os
+cp os/RPM-GPG-KEY* /etc/pki/rpm-gpg/
+rm os -rf
+dnf copr -y enable walters/buildtools-fedora
+dnf -y install dnf-plugins-core fedpkg openssh-clients rpmdistro-gitoverlay
 yum clean all


### PR DESCRIPTION
The `coreos-assembler` container is becoming an entry point for
building many pieces of RHCOS.  We can continue to extend its
functionality by bringing in tools necessary to run the RDGO portion
of the build.

Additionally, I've included a separate commit that changes the build
script to use `dnf` everywhere instead of `yum`