### PR TITLE
README: change imagefactory to libvirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ systems, including:
 
  - [mantle](https://github.com/coreos/mantle)
  - [rpm-ostree](https://github.com/projectatomic/rpm-ostree/)
- - [ImageFactory](https://github.com/redhat-imaging/imagefactory/)
+ - [libvirt](https://github.com/libvirt/libvirt)
 
 Development
 ---


### PR DESCRIPTION
With #9 we are using libvirt and the virt tools directly rather
than using imagefactory. Update the readme accordingly.